### PR TITLE
Continous Stroker Mode

### DIFF
--- a/BPIOClient.py
+++ b/BPIOClient.py
@@ -103,7 +103,7 @@ async def bpstroke(ctx: BPIOContext):
                     if ctx.bplinmaxsstrokes > 0:
                         ctx.bplinmaxsstrokes -= 1
                     else:
-                        ctx.bplinspeed += 100
+                        ctx.bplinspeed += 50
                         if ctx.bplinspeed > 2000:
                             ctx.bplinspeed = 2000
                      


### PR DESCRIPTION
## What is this fixing or adding?
Adds a mode for linear devices to slowly stroke the entire time and get faster as checks are made and items are found
/bpsstart and /bpsstop to start and stop this

## How was this tested?
Use handy to test and everything seems to be working

## If this makes graphical changes, please attach screenshots.
